### PR TITLE
fix: enable and debug interactions endpoint

### DIFF
--- a/src/app/models/interaction.py
+++ b/src/app/models/interaction.py
@@ -24,4 +24,4 @@ class InteractionModel(SQLModel):
     learner_id: int
     item_id: int
     kind: str
-    timestamp: datetime  # BUG: should be 'created_at' to match the database column
+    created_at: datetime  # BUG: should be 'created_at' to match the database column

--- a/src/app/routers/interactions.py
+++ b/src/app/routers/interactions.py
@@ -19,6 +19,6 @@ async def get_interactions(
     interactions = await read_interactions(session)
     if item_id is not None:
         interactions = [
-            i for i in interactions if i.learner_id == item_id
+            i for i in interactions if i.item_id == item_id
         ]  # BUG: should filter by i.item_id
     return interactions


### PR DESCRIPTION
## Summary

This PR enables the `/interactions` endpoint and addresses two critical bugs identified during the debugging process:

1. **Bug 1 (Schema Mismatch)**: Renamed the `timestamp` field to `created_at` in the `InteractionModel` class to align the response schema with the database table structure.
2. **Bug 2 (Logic Error)**: Updated the filtering logic in the interactions router to correctly filter results by `item_id` instead of `learner_id`.

The fixes were verified using Swagger UI, confirming that the API now returns a `200 OK` status and data consistent with the database.

- Closes #3 

---

## Checklist

- [x] I made this PR to the `main` branch **of my fork (NOT the course instructors' repo)**.
- [x] I see `base: main` <- `compare: task-2-debug-interactions` above the PR title.
- [x] I edited the line `- Closes #3 `.
- [x] I wrote clear commit messages.
- [x] I reviewed my own diff before requesting review.
- [x] I understand the changes I’m submitting.