### PR TITLE
feat: implement learners endpoint

### DIFF
--- a/src/app/routers/learners.py
+++ b/src/app/routers/learners.py
@@ -2,14 +2,14 @@
 
 from fastapi import APIRouter
 
-# from datetime import datetime
-#
-# from fastapi import Depends
-# from sqlmodel.ext.asyncio.session import AsyncSession
-#
-# from app.database import get_session
-# from app.db.learners import read_learners, create_learner
-# from app.models.learner import Learner, LearnerCreate
+from datetime import datetime
+
+from fastapi import Depends
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.database import get_session
+from app.db.learners import read_learners, create_learner
+from app.models.learner import Learner, LearnerCreate
 
 router = APIRouter()
 
@@ -17,20 +17,15 @@ router = APIRouter()
 # PART A: GET endpoint
 # ===
 
-# UNCOMMENT AND FILL IN
-#
-# @router.<method>("/<resource_name>", response_model=list[<resource_schema>])
-# async def <function_name>(
-#     <query_param>: <type> = None,
-#     session: AsyncSession = Depends(get_session),
-# ):
-#     """<docstring>"""
-#     return await <db_read_function>(session, <query_param>)
-#
-# Reference:
-# items GET -> reads from items table, returns list[Item]
-# learners GET -> reads from learners table, returns list[Learner]
-# Query parameter: ?enrolled_after= filters learners by enrolled_at date
+
+@router.get("/", response_model=list[Learner])
+async def get_learners(
+    enrolled_after: datetime | None = None,
+    session: AsyncSession = Depends(get_session),
+):
+    """Get all learners, optionally filtered by enrollment date."""
+    return await read_learners(session, enrolled_after)
+
 
 # ===
 # PART B: POST endpoint

--- a/src/app/routers/learners.py
+++ b/src/app/routers/learners.py
@@ -31,16 +31,11 @@ async def get_learners(
 # PART B: POST endpoint
 # ===
 
-# UNCOMMENT AND FILL IN
-#
-# @router.<method>("/<resource_name>", response_model=<resource_schema>, status_code=<status_code>)
-# async def <function_name>(
-#     <param_name>: <request_schema>,
-#     session: AsyncSession = Depends(get_session),
-# ):
-#     """<docstring>"""
-#     return await <db_create_function>(session, name=<param_name>.name, email=<param_name>.email)
-#
-# Reference:
-# items POST -> creates a row in items table, accepts ItemCreate, returns Item with status 201
-# learners POST -> creates a row in learners table, accepts LearnerCreate, returns Learner with status 201
+
+@router.post("/", response_model=Learner, status_code=201)
+async def post_learner(
+    body: LearnerCreate,
+    session: AsyncSession = Depends(get_session),
+):
+    """Create a new learner."""
+    return await create_learner(session, name=body.name, email=body.email)


### PR DESCRIPTION
## Summary

This PR implements the `/learners` endpoint by providing GET and POST functionality:

1. **GET /learners**: Added an endpoint to retrieve a list of all learners with an optional `enrolled_after` query parameter for date filtering.
2. **POST /learners**: Added an endpoint to create new learner records in the database.

The implementation was verified using Swagger UI, confirming that GET requests return the correct list of students (including filtering by enrollment date) and POST requests correctly create new records with a 201 status code.

- Closes #5 

---

## Checklist

- [x] I made this PR to the `main` branch **of my fork (NOT the course instructors' repo)**.
- [x] I see `base: main` <- `compare: task-3-implement-learners` above the PR title.
- [x] I edited the line `- Closes #5 `.
- [x] I wrote clear commit messages (separate commits for GET and POST).
- [x] I reviewed my own diff before requesting review.
- [x] I understand the changes I’m submitting.